### PR TITLE
Julia output adapter

### DIFF
--- a/examples/converter/src/Main.elm
+++ b/examples/converter/src/Main.elm
@@ -12,6 +12,7 @@ import Lofi.Schema.Output.ReactProps as ReactProps
 import Lofi.Schema.Output.Swift as Swift
 import Lofi.Schema.Output.Elm as Elm
 import Lofi.Schema.Output.Go as Go
+import Lofi.Schema.Output.Julia as Julia
 
 
 type alias Model =
@@ -48,12 +49,12 @@ update msg model =
       ( { model | collectionName = newName }
       , Cmd.none
       )
-    
+
     ChangeIndividualName newName ->
       ( { model | individualName = newName }
       , Cmd.none
       )
-    
+
     ChangeSchemaText text ->
       ( { model | lines = String.split "\n" text }
       , Cmd.none
@@ -174,6 +175,10 @@ view model =
       [ h2 [] [ text "MySQL" ]
       , viewCode (MySQL.createTableCommand schema)
       , viewCode (MySQL.insertRowCommand schema)
+      ]
+    , article []
+      [ h2 [] [ text "Julia (v0.6+)" ]
+      , viewCode (Julia.createStructCode schema)
       ]
     ]
 

--- a/src/Lofi/Schema/Output/Julia.elm
+++ b/src/Lofi/Schema/Output/Julia.elm
@@ -1,0 +1,149 @@
+module Lofi.Schema.Output.Julia exposing
+  ( createStructCode
+  )
+
+{-|
+
+# Functions
+@docs createStructCode
+-}
+
+import Lofi.Schema exposing (Schema, Item, Kind(..))
+import String.Extra exposing (underscored, camelize, decapitalize, quote)
+
+
+lowerCamelize : String -> String
+lowerCamelize = camelize >> decapitalize
+
+pairsToStructFields : String -> List (String, String) -> String
+pairsToStructFields name pairs =
+  let
+    propertyDivider =
+      "\n  "
+
+    innerCode =
+      pairs
+      |> List.map (\(a, b) -> "" ++ a ++ "::" ++ b)
+      |> String.join propertyDivider
+
+  in
+    innerCode
+
+createRecordPropertiesCodeFold : Item -> List (String, String) -> List (String, String)
+createRecordPropertiesCodeFold item list =
+  let
+    nativeKind =
+      case item.kind of
+        Text _ ->
+          "AbstractString"
+        Number { real } ->
+          if real then
+            "Float64"
+          else
+            "Int64"
+        Date { time } ->
+          if time then
+            "DateTime"
+          else
+            "Date"
+
+    propertyName =
+      lowerCamelize item.name
+
+    schemaString =
+      [ Just nativeKind
+      ]
+      |> List.filterMap identity
+      |> String.join ""
+
+    field =
+      (propertyName, schemaString)
+
+  in
+    field :: list
+
+
+-- 3-tuple contains propertyName, constraint predicate, error call
+itemToConstraintViolations : Item -> List (String, String, String) -> List (String, String, String)
+itemToConstraintViolations item list =
+  let
+    propertyName =
+      lowerCamelize item.name
+
+    predicate =
+      case item.kind of
+        Text { maximumLength } ->
+          case maximumLength of
+            Just ml ->
+              "(length(" ++ propertyName ++ ") > " ++ toString ml ++ ")"
+            Nothing ->
+              ""
+        Number { allowNegative } ->
+          if allowNegative then
+            ""
+          else
+            "(" ++ propertyName ++ " < 0)"
+        _ -> ""
+
+    errorMsg =
+      "error(\"Constraint on " ++ propertyName ++ " violated\")"
+  in
+    case predicate of
+      "" -> list
+      _ -> (propertyName, predicate, errorMsg) :: list
+
+
+createInnerCtor : String -> List Item -> List (String, String, String) -> String
+createInnerCtor objectName items constraints =
+  let
+    argList =
+      String.join ", " (List.map (\item -> lowerCamelize item.name) items)
+
+    lhs =
+      objectName ++ "(" ++ argList ++ ")"
+
+    constraintString =
+      case constraints of
+        [] -> ""
+        _ ->
+          String.join "\n    elseif " (List.map (\(_, pred, err) -> pred ++ "\n      " ++ err) constraints)
+
+    newCall =
+      "new(" ++ argList ++ ")"
+
+    rhs =
+      case constraintString of
+        "" -> newCall
+        _ ->
+          "if " ++ constraintString ++ "\n    else\n      " ++ newCall ++ "\n    end"
+  in
+    case constraintString of
+      "" -> "" -- Default ctor suffices when no constraints
+      _ -> "\n\n  " ++ lhs ++ " =\n    " ++ rhs
+
+
+{-| Generates Julia code declaring a composite type -}
+createStructCode : Schema -> String
+createStructCode schema =
+  let
+
+    objectName = camelize schema.individualName
+
+    structCode =
+      List.foldr createRecordPropertiesCodeFold [] schema.items
+      |> pairsToStructFields (camelize schema.individualName)
+
+    constraints =
+      List.foldr itemToConstraintViolations [] schema.items
+
+    innerCtor =
+      createInnerCtor objectName schema.items constraints
+  in
+    "struct " ++ objectName ++ "\n  " ++ structCode ++ innerCtor ++ "\nend"
+
+
+  {- Handling optional values could be done via an outer constructor using
+     keyword args, or by modeling values with a Nullable. Both strategies make
+     assumptions that will be wrong in enough cases to simply omit handling
+     optional values and default values here.
+   -}


### PR DESCRIPTION
Finally had a chance to write the Julia output adapter I mentioned last week.

I've included logic to enforce invariant constraints for `maximumLength` and `allowNegative` -- although I noticed the latter one isn't currently being picked up in Schema.elm.

Tangentially related question: Is the `email` tag to hint that the value of that property should be validated against an email regex?